### PR TITLE
Extend fairness metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,4 +173,3 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 data/
-notebooks/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This project aims to build a credit scoring model and explore techniques to iden
 
 ## Project Goals
 - Develop a baseline credit scoring model.
-- Implement and calculate fairness metrics (e.g., demographic parity, equalized odds).
+- Implement and calculate fairness metrics (e.g., demographic parity difference, equalized odds difference,
+  false positive/negative rate differences, accuracy difference).
 - Apply at least one bias mitigation technique (e.g., re-weighting, adversarial debiasing, or a post-processing method).
 - Evaluate and compare the model's performance and fairness before and after mitigation.
 - Discuss the trade-offs between fairness and accuracy.
@@ -49,8 +50,16 @@ pip install -r requirements.txt
 ## Usage
 The dataset is generated automatically the first time you run the pipeline. Execute the evaluation script to train the model and print fairness metrics:
 ```bash
-python src/evaluate_fairness.py  # add --help for options
+python -m src.evaluate_fairness  # add --help for options
 ```
+Choose a training method with `--method`. Options are `baseline`,
+`reweight`, or `postprocess`. Use `--test-size` to adjust the train/test
+split (default 0.3) and `--random-state` for reproducible splits.
+Pass `--output-json metrics.json` to also save the results to a file.
+Interactive exploration is available in `notebooks/fairness_exploration.ipynb`,
+which demonstrates running the pipeline with each mitigation approach.
+The `run_pipeline` function used by the CLI also returns a dictionary of the
+accuracy and fairness metrics so you can incorporate the results programmatically.
 
 ## Testing
 Run the unit tests with pytest:

--- a/notebooks/fairness_exploration.ipynb
+++ b/notebooks/fairness_exploration.ipynb
@@ -1,0 +1,50 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Fairness Exploration\n",
+        "This notebook demonstrates how to run the evaluation pipeline and inspect fairness metrics using different mitigation methods."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from src.evaluate_fairness import run_pipeline\n",
+        "\n",
+        "# Baseline\n",
+        "run_pipeline(method='baseline')\n",
+        "\n",
+        "# Reweighting mitigation\n",
+        "run_pipeline(method='reweight')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "# Post-processing mitigation\n",
+        "run_pipeline(method='postprocess')"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/src/baseline_model.py
+++ b/src/baseline_model.py
@@ -9,7 +9,10 @@ def train_baseline_model(X_train, y_train, sample_weight=None):
     return model
 
 
-def evaluate_model(model, X_test, y_test):
-    """Return accuracy score for the model."""
-    predictions = model.predict(X_test)
-    return accuracy_score(y_test, predictions)
+def evaluate_model(model, X_test, y_test, sensitive_features=None):
+    """Return accuracy score and predictions for the model."""
+    if sensitive_features is not None:
+        predictions = model.predict(X_test, sensitive_features=sensitive_features)
+    else:
+        predictions = model.predict(X_test)
+    return accuracy_score(y_test, predictions), predictions

--- a/src/bias_mitigator.py
+++ b/src/bias_mitigator.py
@@ -16,3 +16,34 @@ def reweight_samples(y, protected):
         weights[group] = total / (len(counts) * row["count"])
 
     return [weights[(yi, pi)] for yi, pi in zip(df["y"], df["protected"])]
+
+
+def postprocess_equalized_odds(model, X, y, protected):
+    """Post-process predictions using the Equalized Odds constraint.
+
+    Parameters
+    ----------
+    model : estimator
+        A fitted scikit-learn compatible classifier with ``predict_proba``.
+    X : pandas.DataFrame
+        Training features.
+    y : array-like
+        Training labels.
+    protected : array-like
+        Protected attribute values for each training sample.
+
+    Returns
+    -------
+    ThresholdOptimizer
+        A post-processed classifier enforcing the equalized odds constraint.
+    """
+    from fairlearn.postprocessing import ThresholdOptimizer
+
+    optimizer = ThresholdOptimizer(
+        estimator=model,
+        constraints="equalized_odds",
+        predict_method="predict_proba",
+        prefit=True,
+    )
+    optimizer.fit(X, y, sensitive_features=protected)
+    return optimizer

--- a/src/data_loader_preprocessor.py
+++ b/src/data_loader_preprocessor.py
@@ -18,8 +18,8 @@ def load_credit_data(path="data/credit_data.csv", test_size=0.3, random_state=42
 
     Returns
     -------
-    tuple(pd.DataFrame, pd.Series, pd.DataFrame, pd.Series)
-        X_train, y_train, X_test, y_test
+    tuple(pd.DataFrame, pd.DataFrame, pd.Series, pd.Series)
+        X_train, X_test, y_train, y_test
     """
     if os.path.exists(path):
         df = pd.read_csv(path)

--- a/src/evaluate_fairness.py
+++ b/src/evaluate_fairness.py
@@ -1,31 +1,116 @@
-from data_loader_preprocessor import load_credit_data
-from baseline_model import train_baseline_model, evaluate_model
-from bias_mitigator import reweight_samples
-from fairness_metrics import compute_fairness_metrics
+import argparse
+
+from .data_loader_preprocessor import load_credit_data
+from .baseline_model import train_baseline_model, evaluate_model
+from .bias_mitigator import reweight_samples, postprocess_equalized_odds
+from .fairness_metrics import compute_fairness_metrics
 
 
-def run_pipeline(use_mitigation=False):
-    X_train, X_test, y_train, y_test = load_credit_data()
+def run_pipeline(method="baseline", test_size=0.3, output_path=None, random_state=42):
+    """Train the model and return accuracy and fairness metrics.
+
+    Parameters
+    ----------
+    method : str, optional
+        Training approach: ``"baseline"`` (default), ``"reweight"``, or ``"postprocess"``.
+    test_size : float, optional
+        Portion of the data to reserve for testing, by default 0.3.
+    output_path : str or None, optional
+        If provided, the returned metrics dictionary will also be written to the
+        given JSON file.
+    random_state : int, optional
+        Random seed used when splitting the data, by default 42.
+
+    Returns
+    -------
+    dict
+        Dictionary containing ``accuracy``, ``overall``, and ``by_group`` metrics.
+    """
+
+    X_train, X_test, y_train, y_test = load_credit_data(
+        test_size=test_size, random_state=random_state
+    )
 
     features_train = X_train.drop("protected", axis=1)
     features_test = X_test.drop("protected", axis=1)
 
-    if use_mitigation:
+    if method == "reweight":
         sample_weights = reweight_samples(y_train, X_train["protected"])
         model = train_baseline_model(features_train, y_train, sample_weight=sample_weights)
     else:
         model = train_baseline_model(features_train, y_train)
+        if method == "postprocess":
+            model = postprocess_equalized_odds(
+                model,
+                features_train,
+                y_train,
+                X_train["protected"],
+            )
 
-    accuracy = evaluate_model(model, features_test, y_test)
+    if method == "postprocess":
+        accuracy, preds = evaluate_model(
+            model,
+            features_test,
+            y_test,
+            sensitive_features=X_test["protected"],
+        )
+    else:
+        accuracy, preds = evaluate_model(model, features_test, y_test)
+
     overall, by_group = compute_fairness_metrics(
         y_true=y_test,
-        y_pred=model.predict(features_test),
+        y_pred=preds,
         protected=X_test["protected"],
     )
     print(f"Accuracy: {accuracy:.3f}")
     print("Overall fairness metrics:\n", overall)
     print("Metrics by group:\n", by_group)
 
+    results = {"accuracy": accuracy, "overall": overall, "by_group": by_group}
+    if output_path is not None:
+        import json
+
+        with open(output_path, "w") as f:
+            json.dump(results, f, default=str)
+
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate model fairness")
+    parser.add_argument(
+        "--method",
+        choices=["baseline", "reweight", "postprocess"],
+        default="baseline",
+        help="Training method to use",
+    )
+    parser.add_argument(
+        "--test-size",
+        type=float,
+        default=0.3,
+        help="Proportion of data to use for testing",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=str,
+        default=None,
+        help="Optional path to write metrics as JSON",
+    )
+    parser.add_argument(
+        "--random-state",
+        type=int,
+        default=42,
+        help="Random seed for the train/test split",
+    )
+    args = parser.parse_args()
+
+    run_pipeline(
+        method=args.method,
+        test_size=args.test_size,
+        output_path=args.output_json,
+        random_state=args.random_state,
+    )
+
 
 if __name__ == "__main__":
-    run_pipeline(use_mitigation=True)
+    main()

--- a/src/fairness_metrics.py
+++ b/src/fairness_metrics.py
@@ -1,5 +1,13 @@
 import pandas as pd
-from fairlearn.metrics import MetricFrame, selection_rate, equalized_odds_difference
+from fairlearn.metrics import (
+    MetricFrame,
+    selection_rate,
+    equalized_odds_difference,
+    demographic_parity_difference,
+    false_positive_rate_difference,
+    false_negative_rate_difference,
+)
+from sklearn.metrics import accuracy_score
 
 
 def compute_fairness_metrics(y_true, y_pred, protected):
@@ -7,11 +15,28 @@ def compute_fairness_metrics(y_true, y_pred, protected):
     if not isinstance(protected, pd.Series):
         protected = pd.Series(protected, name="protected")
 
-    metrics = {"selection_rate": selection_rate}
-    frame = MetricFrame(metrics=metrics, y_true=y_true, y_pred=y_pred, sensitive_features=protected)
+    metrics = {"selection_rate": selection_rate, "accuracy": accuracy_score}
+    frame = MetricFrame(
+        metrics=metrics,
+        y_true=y_true,
+        y_pred=y_pred,
+        sensitive_features=protected,
+    )
 
     eod = equalized_odds_difference(y_true, y_pred, sensitive_features=protected)
+    dpd = demographic_parity_difference(y_true, y_pred, sensitive_features=protected)
+    fpr_diff = false_positive_rate_difference(
+        y_true, y_pred, sensitive_features=protected
+    )
+    fnr_diff = false_negative_rate_difference(
+        y_true, y_pred, sensitive_features=protected
+    )
+
     overall = frame.overall
     overall["equalized_odds_difference"] = eod
+    overall["demographic_parity_difference"] = dpd
+    overall["false_positive_rate_difference"] = fpr_diff
+    overall["false_negative_rate_difference"] = fnr_diff
+    overall["accuracy_difference"] = frame.difference()["accuracy"]
 
     return overall, frame.by_group

--- a/tests/test_fairness_metrics.py
+++ b/tests/test_fairness_metrics.py
@@ -11,5 +11,11 @@ def test_fairness_metrics_balanced():
 
     # When predictions equal labels, equalized_odds_difference should be 0
     assert abs(overall['equalized_odds_difference']) < 1e-6
+    # Demographic parity difference should also be 0
+    assert abs(overall['demographic_parity_difference']) < 1e-6
+    # False positive/negative rate differences should be 0
+    assert abs(overall['false_positive_rate_difference']) < 1e-6
+    assert abs(overall['false_negative_rate_difference']) < 1e-6
+    assert abs(overall['accuracy_difference']) < 1e-6
     # Selection rates should be equal across groups
     assert by_group['selection_rate'][0] == by_group['selection_rate'][1]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,29 @@
+import pytest
+
+from src.evaluate_fairness import run_pipeline
+
+@pytest.mark.parametrize('method', ['baseline', 'reweight', 'postprocess'])
+def test_run_pipeline_returns_metrics(method):
+    results = run_pipeline(method=method, test_size=0.5)
+    assert 'accuracy' in results
+    assert 'overall' in results
+    assert 'by_group' in results
+    assert 'false_positive_rate_difference' in results['overall'].index
+    assert 'accuracy_difference' in results['overall'].index
+
+
+def test_run_pipeline_output_json(tmp_path):
+    out_file = tmp_path / "metrics.json"
+    results = run_pipeline(method="baseline", test_size=0.5, output_path=str(out_file))
+    assert out_file.exists()
+    import json
+    with out_file.open() as f:
+        loaded = json.load(f)
+    assert results["accuracy"] == loaded["accuracy"]
+
+
+def test_run_pipeline_random_state_deterministic():
+    r1 = run_pipeline(method="baseline", test_size=0.5, random_state=123)
+    r2 = run_pipeline(method="baseline", test_size=0.5, random_state=123)
+    assert r1["accuracy"] == r2["accuracy"]
+    assert r1["overall"].equals(r2["overall"])

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -1,0 +1,16 @@
+import numpy as np
+from src.data_loader_preprocessor import load_credit_data
+from src.baseline_model import train_baseline_model
+from src.bias_mitigator import postprocess_equalized_odds
+
+
+def test_postprocess_predict_length():
+    X_train, X_test, y_train, y_test = load_credit_data(test_size=0.5, random_state=0)
+    features_train = X_train.drop("protected", axis=1)
+    features_test = X_test.drop("protected", axis=1)
+
+    base_model = train_baseline_model(features_train, y_train)
+    opt_model = postprocess_equalized_odds(base_model, features_train, y_train, X_train["protected"])
+    preds = opt_model.predict(features_test, sensitive_features=X_test["protected"])
+
+    assert len(preds) == len(y_test)


### PR DESCRIPTION
## Summary
- document false positive/negative rate metrics in README
- compute FPR and FNR differences in `compute_fairness_metrics`
- check new metrics in unit tests
- add accuracy difference metric

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856dfcf51888329bbc19ea80795c874

## Summary by Sourcery

Extend the fairness evaluation pipeline with new metrics, mitigation methods, and a command-line interface while updating documentation and tests.

New Features:
- Add CLI options for selecting mitigation method, test size, random seed, and outputting results to JSON
- Introduce post-processing mitigation using Fairlearn’s ThresholdOptimizer for equalized odds

Enhancements:
- Refactor run_pipeline to return and optionally save accuracy and fairness metrics
- Modify evaluate_model to return both accuracy and raw predictions for downstream processing
- Extend compute_fairness_metrics to include false positive rate difference, false negative rate difference, and accuracy difference

Documentation:
- Update README with documentation for new metrics (FPR/FNR differences, accuracy difference) and CLI usage
- Add a Jupyter notebook demonstrating the evaluation pipeline with different mitigation approaches

Tests:
- Expand unit tests to validate new fairness metrics and accuracy difference
- Add tests for run_pipeline output structure, JSON serialization, and deterministic behavior with random_state
- Add tests to verify post-processing mitigation produces correct-sized predictions

Chores:
- Correct data_loader_preprocessor return value documentation to match actual signature