### PR TITLE
Fix CLI import path and improve metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ cython_debug/
 # PyPI configuration file
 .pypirc
 data/
+metrics.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff
+        args: ["check", "src", "tests", "--quiet"]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.8.5
+    hooks:
+      - id: bandit
+        args: ["-r", "src"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2025-06-27
+### Changed
+- Compute log-loss using probability scores for accuracy
+- Added pre-commit configuration and development requirements
+- CLI now logs output with --verbose option
+- Version bumped for package release
+
 ## [0.1.0] - 2025-06-26
+
+
 ### Added
 - Initial implementation of credit scoring pipeline with bias mitigation
 - Command line interface and public API

--- a/README.md
+++ b/README.md
@@ -51,12 +51,16 @@ Create a virtual environment and install dependencies:
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+pip install -r requirements-dev.txt  # for development tools
+pre-commit install  # set up git hooks for linting
+# The hook runs Ruff and Bandit automatically before each commit
 ```
 
 ## Usage
-The dataset is generated automatically the first time you run the pipeline. Execute the evaluation script to train the model and print fairness metrics:
+The dataset is generated automatically the first time you run the pipeline.
+Run the packaged CLI to train the model and print fairness metrics:
 ```bash
-python -m src.evaluate_fairness  # add --help for options
+fairness-eval  # add --help for options
 ```
 Choose a training method with `--method`. Options are `baseline`,
 `reweight`, `postprocess`, or `expgrad`. Use `--test-size` to adjust the train/test
@@ -68,6 +72,7 @@ easily parsed.
 Use `--cv N` to evaluate with `N`-fold cross-validation instead of a single split.
 Provide `--threshold T` to apply a custom probability threshold `T` when
 converting model scores to predicted labels.
+Use `--verbose` to enable debug-level logging for more detailed output.
 When cross-validation is enabled, the script prints the average metrics across all folds and
 also computes their standard deviation. `--output-json` will write these aggregated results,
 including the per-fold metrics and fold-level statistics, to the specified path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "fair_credit_scorer_bias_mitigation"
-version = "0.1.0"
+version = "0.1.1"
 requires-python = ">=3.8"
 dependencies = [
     "scikit-learn==1.7.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest==8.4.0
+pytest-cov==6.2.1
+ruff==0.11.13
+bandit==1.8.5

--- a/src/baseline_model.py
+++ b/src/baseline_model.py
@@ -1,8 +1,17 @@
+from typing import Iterable, Tuple
+
+import numpy as np
+import pandas as pd
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import accuracy_score
 
 
-def train_baseline_model(X_train, y_train, sample_weight=None, solver="liblinear"):
+def train_baseline_model(
+    X_train: pd.DataFrame | np.ndarray,
+    y_train: pd.Series | np.ndarray,
+    sample_weight: Iterable[float] | None = None,
+    solver: str = "liblinear",
+) -> LogisticRegression:
     """Train a simple logistic regression model.
 
     Parameters
@@ -23,8 +32,13 @@ def train_baseline_model(X_train, y_train, sample_weight=None, solver="liblinear
 
 
 def evaluate_model(
-    model, X_test, y_test, sensitive_features=None, return_probs=False, threshold=None
-):
+    model: LogisticRegression,
+    X_test: pd.DataFrame | np.ndarray,
+    y_test: pd.Series | np.ndarray,
+    sensitive_features: pd.Series | np.ndarray | None = None,
+    return_probs: bool = False,
+    threshold: float | None = None,
+) -> Tuple[float, np.ndarray] | Tuple[float, np.ndarray, np.ndarray | None]:
     """Return accuracy score, predictions, and optionally probabilities.
 
     Parameters

--- a/src/data_loader_preprocessor.py
+++ b/src/data_loader_preprocessor.py
@@ -1,10 +1,14 @@
 import os
+from typing import Tuple
+
 import pandas as pd
 from sklearn.datasets import make_classification
 from sklearn.model_selection import train_test_split
 
 
-def load_credit_dataset(path="data/credit_data.csv", random_state=42):
+def load_credit_dataset(
+    path: str = "data/credit_data.csv", random_state: int = 42
+) -> Tuple[pd.DataFrame, pd.Series]:
     """Return the entire credit dataset as features and labels."""
     if os.path.exists(path):
         df = pd.read_csv(path)
@@ -28,7 +32,11 @@ def load_credit_dataset(path="data/credit_data.csv", random_state=42):
     return X, y
 
 
-def load_credit_data(path="data/credit_data.csv", test_size=0.3, random_state=42):
+def load_credit_data(
+    path: str = "data/credit_data.csv",
+    test_size: float = 0.3,
+    random_state: int = 42,
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.Series, pd.Series]:
     """Load credit data from CSV or generate a synthetic dataset.
 
     Parameters

--- a/src/fair_credit_scorer_bias_mitigation/__init__.py
+++ b/src/fair_credit_scorer_bias_mitigation/__init__.py
@@ -1,6 +1,6 @@
 """Public API for the Fair Credit Scorer package."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 from baseline_model import evaluate_model, train_baseline_model
 from bias_mitigator import (

--- a/src/fair_credit_scorer_bias_mitigation/cli.py
+++ b/src/fair_credit_scorer_bias_mitigation/cli.py
@@ -1,5 +1,5 @@
 """Command-line interface for running model evaluation."""
-from src.evaluate_fairness import main as _main
+from evaluate_fairness import main as _main
 
 
 def main() -> None:

--- a/tests/test_dataset-loader.py
+++ b/tests/test_dataset-loader.py
@@ -1,5 +1,4 @@
 
-import os
 from fair_credit_scorer_bias_mitigation import load_credit_data
 
 

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -1,4 +1,3 @@
-import numpy as np
 from src.data_loader_preprocessor import load_credit_data
 from src.baseline_model import train_baseline_model
 from src.bias_mitigator import postprocess_equalized_odds


### PR DESCRIPTION
## Summary
- compute log_loss with probability scores
- clean up type hints for fairness metrics
- document pre-commit setup in README
- ignore metrics.json files
- bump version and record changelog

## Testing
- `ruff check src tests --quiet`
- `python -m src.run_tests`

------
https://chatgpt.com/codex/tasks/task_e_685d2dec3ec88329b74339adc77a49b2

## Summary by Sourcery

Update fairness evaluation CLI and metrics computation with logging and type refinements, add pre-commit tooling, bump version, and refresh documentation

New Features:
- Add --verbose flag to enable debug-level logging in the CLI

Bug Fixes:
- Fix incorrect import path in the packaged CLI entrypoint

Enhancements:
- Compute log_loss with probability scores and replace print statements with logger calls
- Refine type hints and return annotations across fairness metrics, baseline model, and data loader modules

Build:
- Bump project version to 0.1.1 in pyproject.toml

CI:
- Add pre-commit configuration (Ruff and Bandit) and requirements-dev.txt for development tooling

Documentation:
- Document pre-commit setup and update CLI usage (command name and verbose option) in README.md
- Update CHANGELOG.md with 0.1.1 release notes