### PR TITLE
Refactor imports to use src module, add dependencies, and update test fixtures

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ pytest-cov==6.2.1
 ruff==0.11.13
 bandit==1.8.5
 PyYAML==6.0.1
+shap==0.46.0
+requests==2.32.3

--- a/src/autonomous_backlog_executor.py
+++ b/src/autonomous_backlog_executor.py
@@ -24,8 +24,8 @@ import sys
 import time
 from typing import Optional
 
-from backlog_manager import BacklogManager, BacklogItem, TaskStatus
-from logging_config import setup_logging
+from src.backlog_manager import BacklogManager, BacklogItem, TaskStatus
+from src.logging_config import setup_logging
 
 
 class AutonomousBacklogExecutor:

--- a/src/evaluate_fairness.py
+++ b/src/evaluate_fairness.py
@@ -44,14 +44,14 @@ import logging
 # Import version directly to avoid circular import
 __version__ = "0.2.0"
 
-from data_loader_preprocessor import load_credit_data, load_credit_dataset
-from baseline_model import train_baseline_model, evaluate_model
-from bias_mitigator import (
+from src.data_loader_preprocessor import load_credit_data, load_credit_dataset
+from src.baseline_model import train_baseline_model, evaluate_model
+from src.bias_mitigator import (
     reweight_samples,
     postprocess_equalized_odds,
     expgrad_demographic_parity,
 )
-from fairness_metrics import compute_fairness_metrics
+from src.fairness_metrics import compute_fairness_metrics
 from sklearn.model_selection import StratifiedKFold
 import pandas as pd
 import json

--- a/src/metrics_reporter.py
+++ b/src/metrics_reporter.py
@@ -29,8 +29,8 @@ import matplotlib.dates as mdates
 import pandas as pd
 import yaml
 
-from backlog_manager import BacklogItem, TaskStatus, TaskType
-from security_quality_gates import GateResult, QualityGate
+from src.backlog_manager import BacklogItem, TaskStatus, TaskType
+from src.security_quality_gates import GateResult, QualityGate
 
 logger = logging.getLogger(__name__)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 
 from src.config import reset_config
-from src.data_loader_preprocessor import generate_data
+from src.data_loader_preprocessor import generate_synthetic_credit_data as generate_data
 
 
 @pytest.fixture(autouse=True)

--- a/tests/performance/test_benchmarks.py
+++ b/tests/performance/test_benchmarks.py
@@ -7,7 +7,7 @@ import tempfile
 import pytest
 
 from src.evaluate_fairness import run_pipeline
-from src.data_loader_preprocessor import generate_data
+from src.data_loader_preprocessor import generate_synthetic_credit_data as generate_data
 
 
 class TestPerformanceBenchmarks:

--- a/tests/test_end_to_end_workflows.py
+++ b/tests/test_end_to_end_workflows.py
@@ -34,7 +34,7 @@ try:
     from src.config import Config, get_config, reset_config
     from src.performance_benchmarking import PerformanceBenchmark
     from src.data_versioning import DataVersionManager
-    from src.fairness_metrics import calculate_fairness_metrics
+    from src.fairness_metrics import compute_fairness_metrics as calculate_fairness_metrics
     from src.bias_mitigator import BiasPostprocessor
 except ImportError as e:
     pytest.skip(f"Required modules not available: {e}", allow_module_level=True)


### PR DESCRIPTION
## Summary
- Refactored import statements across multiple source files to use the `src` module prefix for better project structure and clarity.
- Added new dependencies `shap==0.46.0` and `requests==2.32.3` to `requirements.txt`.
- Updated test fixtures and imports to use `generate_synthetic_credit_data` instead of `generate_data` for synthetic data generation.
- Renamed import alias in tests for consistency (`compute_fairness_metrics` as `calculate_fairness_metrics`).

## Changes

### Source Code
- Updated imports in `src/autonomous_backlog_executor.py`, `src/evaluate_fairness.py`, and `src/metrics_reporter.py` to use `src.` prefix.

### Dependencies
- Added `shap` and `requests` packages to `requirements.txt`.

### Tests
- Modified `tests/conftest.py` and `tests/performance/test_benchmarks.py` to import `generate_synthetic_credit_data` as `generate_data`.
- Updated `tests/test_end_to_end_workflows.py` to import `compute_fairness_metrics` as `calculate_fairness_metrics` for consistency.

## Test plan
- [x] Run all existing tests to ensure no breakage due to import changes.
- [x] Verify that synthetic data generation works correctly in tests.
- [x] Confirm that new dependencies are installed and compatible with the project.
- [x] Validate end-to-end workflows and performance benchmarks pass successfully.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/bdb589ec-60c7-4685-8535-af21950ab1b3

## Summary by Sourcery

Refactor imports to use the src namespace, add shap and requests dependencies, and update tests to use the new synthetic data generator and standardized fairness metrics alias

Enhancements:
- Refactor core modules to import via the src. prefix for a consistent project structure

Build:
- Add shap==0.46.0 and requests==2.32.3 to requirements.txt

Tests:
- Update test fixtures and imports to use generate_synthetic_credit_data in place of generate_data and standardize compute_fairness_metrics alias